### PR TITLE
Phase 2: Admin Controls (H-1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3037,14 +3037,12 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.24",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.24.tgz",
       "integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -3055,7 +3053,7 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
@@ -4009,7 +4007,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -7679,7 +7676,6 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-markdown": {

--- a/src/icpi_backend/src/1_CRITICAL_OPERATIONS/burning/mod.rs
+++ b/src/icpi_backend/src/1_CRITICAL_OPERATIONS/burning/mod.rs
@@ -67,7 +67,7 @@ pub async fn burn_icpi(caller: Principal, amount: Nat) -> Result<BurnResult> {
 
     match allowance_result {
         Ok((allowance,)) => {
-            let required_fee = Nat::from(crate::infrastructure::constants::MINT_FEE_E6);
+            let required_fee = Nat::from(crate::infrastructure::constants::MINT_FEE_AMOUNT);
             if allowance.allowance < required_fee {
                 ic_cdk::println!(
                     "⚠️ Insufficient fee approval: user approved {} e6, required {} e6",

--- a/src/icpi_backend/src/1_CRITICAL_OPERATIONS/burning/mod.rs
+++ b/src/icpi_backend/src/1_CRITICAL_OPERATIONS/burning/mod.rs
@@ -32,6 +32,9 @@ pub struct BurnResult {
 // SECURITY: ICRC-2 prevents race conditions because each burn atomically pulls
 // from the specific user's approved tokens, not from a shared pool
 pub async fn burn_icpi(caller: Principal, amount: Nat) -> Result<BurnResult> {
+    // Check not paused (Phase 2: H-1)
+    crate::infrastructure::check_not_paused()?;
+
     // Acquire reentrancy guard - prevents concurrent burns by same user
     let _guard = crate::infrastructure::BurnGuard::acquire(caller)?;
 

--- a/src/icpi_backend/src/1_CRITICAL_OPERATIONS/minting/mint_orchestrator.rs
+++ b/src/icpi_backend/src/1_CRITICAL_OPERATIONS/minting/mint_orchestrator.rs
@@ -38,6 +38,9 @@ pub async fn initiate_mint(caller: Principal, amount: Nat) -> Result<String> {
 
 /// Complete a pending mint request
 pub async fn complete_mint(caller: Principal, mint_id: String) -> Result<Nat> {
+    // Check not paused (Phase 2: H-1)
+    crate::infrastructure::check_not_paused()?;
+
     // Acquire reentrancy guard - prevents concurrent mints by same user
     let _guard = crate::infrastructure::MintGuard::acquire(caller)?;
 

--- a/src/icpi_backend/src/1_CRITICAL_OPERATIONS/rebalancing/mod.rs
+++ b/src/icpi_backend/src/1_CRITICAL_OPERATIONS/rebalancing/mod.rs
@@ -162,6 +162,9 @@ pub fn start_rebalancing_timer() {
 /// Executes a single rebalancing cycle immediately.
 /// Useful for testing or emergency interventions.
 pub async fn perform_rebalance() -> Result<String> {
+    // Check not paused (Phase 2: H-1 fix)
+    crate::infrastructure::check_not_paused()?;
+
     ic_cdk::println!("🔧 Manual rebalance triggered");
 
     // Check if rebalancing is already in progress
@@ -219,6 +222,13 @@ pub fn get_rebalancer_status() -> RebalancerStatus {
 /// 3. Execute buy or sell based on priority
 /// 4. Record result for history
 async fn hourly_rebalance() -> Result<String> {
+    // Check not paused (Phase 2: H-1 fix)
+    // Emergency pause should block ALL state-changing operations including rebalancing
+    if let Err(e) = crate::infrastructure::check_not_paused() {
+        ic_cdk::println!("⏭️ Skipping rebalance cycle: System is paused");
+        return Err(e);
+    }
+
     ic_cdk::println!("🔄 Starting hourly rebalance cycle...");
 
     // Get current portfolio state (includes deviations)

--- a/src/icpi_backend/src/6_INFRASTRUCTURE/admin/mod.rs
+++ b/src/icpi_backend/src/6_INFRASTRUCTURE/admin/mod.rs
@@ -1,0 +1,151 @@
+//! Admin Controls Module
+//!
+//! Provides emergency pause, manual operation triggers, and admin logging
+//! for the ICPI backend canister.
+//!
+//! Security Note: Admin principals are hardcoded and verified at runtime.
+//! Only controller/deployer principals should have admin access.
+
+use candid::Principal;
+use std::cell::RefCell;
+use crate::infrastructure::{IcpiError, Result};
+
+/// Admin principals allowed to call admin functions
+///
+/// Includes:
+/// - Backend canister itself (for timer-triggered operations)
+/// - Deployer principal (for manual interventions)
+const ADMIN_PRINCIPALS: &[&str] = &[
+    "ev6xm-haaaa-aaaap-qqcza-cai",  // Backend (for timers)
+    "67ktx-ln42b-uzmo5-bdiyn-gu62c-cd4h4-a5qt3-2w3rs-cixdl-iaso2-mqe",  // Deployer
+];
+
+/// Require caller is an admin principal
+pub fn require_admin() -> Result<()> {
+    let caller = ic_cdk::caller();
+
+    let is_admin = ADMIN_PRINCIPALS.iter().any(|p| {
+        Principal::from_text(p)
+            .map(|admin| admin == caller)
+            .unwrap_or(false)
+    });
+
+    if is_admin {
+        Ok(())
+    } else {
+        Err(IcpiError::Other(format!(
+            "Authorization failed: {} is not an admin principal",
+            caller.to_text()
+        )))
+    }
+}
+
+/// Emergency pause state
+thread_local! {
+    static EMERGENCY_PAUSE: RefCell<bool> = RefCell::new(false);
+}
+
+/// Admin action log entry
+#[derive(Clone, candid::CandidType, candid::Deserialize, serde::Serialize)]
+pub struct AdminAction {
+    pub timestamp: u64,
+    pub admin: Principal,
+    pub action: String,
+}
+
+/// Admin action log storage
+thread_local! {
+    static ADMIN_LOG: RefCell<Vec<AdminAction>> = RefCell::new(Vec::new());
+}
+
+const MAX_LOG_ENTRIES: usize = 1000;
+
+/// Log an admin action
+pub fn log_admin_action(action: String) {
+    ADMIN_LOG.with(|log| {
+        let mut log = log.borrow_mut();
+
+        log.push(AdminAction {
+            timestamp: ic_cdk::api::time(),
+            admin: ic_cdk::caller(),
+            action: action.clone(),
+        });
+
+        // Keep only last 1000 entries
+        let len = log.len();
+        if len > MAX_LOG_ENTRIES {
+            log.drain(0..(len - MAX_LOG_ENTRIES));
+        }
+    });
+
+    ic_cdk::println!("📝 Admin action: {} by {}", action, ic_cdk::caller());
+}
+
+/// Check if system is paused
+pub fn check_not_paused() -> Result<()> {
+    EMERGENCY_PAUSE.with(|p| {
+        if *p.borrow() {
+            Err(IcpiError::Other("System is emergency paused".to_string()))
+        } else {
+            Ok(())
+        }
+    })
+}
+
+/// Activate emergency pause
+pub fn set_pause(paused: bool) {
+    EMERGENCY_PAUSE.with(|p| *p.borrow_mut() = paused);
+}
+
+/// Get current pause state
+pub fn is_paused() -> bool {
+    EMERGENCY_PAUSE.with(|p| *p.borrow())
+}
+
+/// Get admin action log
+pub fn get_admin_log() -> Vec<AdminAction> {
+    ADMIN_LOG.with(|log| log.borrow().clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_admin_principals_valid() {
+        for principal_text in ADMIN_PRINCIPALS {
+            assert!(
+                Principal::from_text(principal_text).is_ok(),
+                "Invalid principal: {}",
+                principal_text
+            );
+        }
+    }
+
+    #[test]
+    fn test_pause_state_default() {
+        // Initial state should be not paused
+        assert!(!is_paused());
+    }
+
+    #[test]
+    fn test_pause_toggle() {
+        set_pause(true);
+        assert!(is_paused());
+
+        set_pause(false);
+        assert!(!is_paused());
+    }
+
+    #[test]
+    fn test_check_not_paused() {
+        set_pause(false);
+        assert!(check_not_paused().is_ok());
+
+        set_pause(true);
+        assert!(check_not_paused().is_err());
+
+        // Reset for other tests
+        set_pause(false);
+    }
+}

--- a/src/icpi_backend/src/6_INFRASTRUCTURE/errors/mod.rs
+++ b/src/icpi_backend/src/6_INFRASTRUCTURE/errors/mod.rs
@@ -127,6 +127,7 @@ pub enum SystemError {
     StateCorrupted { reason: String },
     InterCanisterCallFailed { canister: String, method: String, reason: String },
     OperationInProgress { operation: String, user: String },
+    EmergencyPause,
 }
 
 // Query errors

--- a/src/icpi_backend/src/6_INFRASTRUCTURE/mod.rs
+++ b/src/icpi_backend/src/6_INFRASTRUCTURE/mod.rs
@@ -10,9 +10,11 @@ pub mod cache;
 pub mod rate_limiting;
 pub mod reentrancy;
 pub mod stable_storage;
+pub mod admin;
 
 // Re-export commonly used items
 pub use constants::*;
 pub use errors::{IcpiError, Result, MintError, BurnError, RebalanceError, ValidationError, CalculationError, TradingError, KongswapError, SystemError};
 pub use math::{multiply_and_divide, convert_decimals, calculate_mint_amount};
 pub use reentrancy::{MintGuard, BurnGuard};
+pub use admin::{require_admin, check_not_paused, log_admin_action, set_pause, is_paused, get_admin_log, AdminAction};


### PR DESCRIPTION
## Summary

Implements Phase 2 (H-1) of the Security Remediation Plan: Comprehensive admin controls with emergency pause, manual operation triggers, and admin action logging.

### Changes

**Admin Infrastructure Module** (`6_INFRASTRUCTURE/admin/mod.rs`):
- Emergency pause state management
- Admin authorization (backend + deployer principal)
- Admin action logging with 1000-entry history
- Pause state checking

**Public Admin API** (`lib.rs`):
- `emergency_pause()` - Stop all minting and burning
- `emergency_unpause()` - Resume operations
- `is_emergency_paused()` - Query pause state
- `get_admin_action_log()` - View admin actions (admin-only)
- `clear_all_caches()` - Clear all system caches

**Critical Operation Protection**:
- Minting: Pause check in `complete_mint()`
- Burning: Pause check in `burn_icpi()`
- Queries: Not affected by pause (read-only operations continue)

### Security Improvements

✅ Admin-only functions protected by `require_admin()`
✅ Emergency pause blocks minting and burning (not queries)
✅ All admin actions logged with timestamp and principal
✅ Deployer principal added to admin list
✅ Thread-local state for pause flag and admin log

### Testing

Tested on mainnet (ev6xm-haaaa-aaaap-qqcza-cai):
- ✅ Emergency pause activation
- ✅ Emergency pause deactivation
- ✅ Admin action logging (2 entries recorded)
- ✅ Cache clearing function
- ✅ Non-admin authorization rejection (expected)

### Mainnet Verification

```bash
# Test emergency pause
dfx canister --network ic call ev6xm-haaaa-aaaap-qqcza-cai emergency_pause
# Result: (variant { 17_724 }) - Success (Ok result)

# Check pause state
dfx canister --network ic call ev6xm-haaaa-aaaap-qqcza-cai is_emergency_paused --query
# Result: (true)

# Unpause
dfx canister --network ic call ev6xm-haaaa-aaaap-qqcza-cai emergency_unpause
# Result: (variant { 17_724 }) - Success

# View admin log
dfx canister --network ic call ev6xm-haaaa-aaaap-qqcza-cai get_admin_action_log --query
# Result: 2 actions logged (PAUSE and UNPAUSE)
```

### Next Steps

- Phase 3: Medium-severity fixes (M-1 through M-5)
- Phase 4: Comprehensive test suite
- Phase 5: Production preparation

🤖 Generated with [Claude Code](https://claude.com/claude-code)